### PR TITLE
Fix the bug where the capacity is incorrectly calculated.

### DIFF
--- a/bitarray/sparse_bitarray.go
+++ b/bitarray/sparse_bitarray.go
@@ -178,7 +178,7 @@ func (sba *sparseBitArray) Capacity() uint64 {
 		return 0
 	}
 
-	return sba.indices[len(sba.indices)-1] + s
+	return (sba.indices[len(sba.indices)-1] + 1) * s
 }
 
 // Equals returns a bool indicating if the provided bit array


### PR DESCRIPTION
The capacity should be s timed with the number of blocks, instead of added with. Also, the block numbers are zero-based, so a "+1" is needed to get to the correct number.
